### PR TITLE
Resolve #130: Add "Eye" icon to password field in login page

### DIFF
--- a/home/templates/base.html
+++ b/home/templates/base.html
@@ -8,6 +8,7 @@
         <title>{% block title %}یادگاه - Yadgah{% endblock %}</title>
         <link rel="icon" href="{% static 'favicon.ico' %}" type="image/x-icon" />
         <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn@v33.003/Vazirmatn-font-face.css" rel="stylesheet" type="text/css" />
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
         <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 
         {% load bootstrap5 %} {% bootstrap_css %} {% bootstrap_javascript %}

--- a/home/templates/login.html
+++ b/home/templates/login.html
@@ -10,8 +10,12 @@
     </div>
     <div class="mb-3">
       <label for="id_password" class="form-label">رمز عبور</label>
-      {{ form.password|add_class:"form-control" }}
-    </div>
+      <div class="position-relative">
+        {{ form.password|add_class:"form-control" }}
+        <span class="position-absolute start-0 top-50 translate-middle-y p-2" style="cursor: pointer; color: black;" onclick="togglePassword()">
+          <i class="bi bi-eye" id="togglePasswordIcon"></i>
+        </span>
+      </div>    </div>
     <div class="d-grid gap-2">
       <button type="submit" class="btn btn-primary">ورود</button>
     </div>
@@ -27,4 +31,21 @@
   </div>
   {% endif %}
 </div>
+
+<script>
+  function togglePassword() {
+      const passwordField = document.querySelector('#id_password');
+      const toggleIcon = document.querySelector('#togglePasswordIcon');
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          toggleIcon.classList.remove('bi-eye');
+          toggleIcon.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          toggleIcon.classList.remove('bi-eye-slash');
+          toggleIcon.classList.add('bi-eye');
+      }
+  }
+  </script>
+
 {% endblock %}

--- a/home/templates/signup.html
+++ b/home/templates/signup.html
@@ -51,7 +51,12 @@
     </div>
     <div class="mb-3">
       <label for="{{ form.password.id_for_label }}" class="form-label">رمز عبور</label>
-      {{ form.password|add_class:"form-control" }}
+      <div class="position-relative">
+        {{ form.password|add_class:"form-control" }}
+        <span class="position-absolute start-0 top-50 translate-middle-y p-2" style="cursor: pointer; color: black;" onclick="togglePassword()">
+          <i class="bi bi-eye" id="togglePasswordIcon"></i>
+        </span>
+      </div>
       <small class="text-muted">رمز باید شامل حداقل ۸ کاراکتر و عدد باشد.</small>
     </div>
     <!-- <div class="mb-3">
@@ -66,5 +71,21 @@
     </div>
   </form>
 </div>
+
+<script>
+  function togglePassword() {
+      const passwordField = document.querySelector('#id_password');
+      const toggleIcon = document.querySelector('#togglePasswordIcon');
+      if (passwordField.type === 'password') {
+          passwordField.type = 'text';
+          toggleIcon.classList.remove('bi-eye');
+          toggleIcon.classList.add('bi-eye-slash');
+      } else {
+          passwordField.type = 'password';
+          toggleIcon.classList.remove('bi-eye-slash');
+          toggleIcon.classList.add('bi-eye');
+      }
+  }
+  </script>
 
 {% endblock %}


### PR DESCRIPTION
- Added an eye icon to the password field, allowing users to toggle between showing/hiding the password.
- Set the icon color to black and positioned it at the end of the input field (left side in RTL).
- Adjusted HTML structure with an additional div for precise positioning.
- Utilized Bootstrap Icons for the eye icon.