### PR TITLE
Optimized Post titles in the Post_list to limited Char_length.

### DIFF
--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -31,7 +31,7 @@
                     <div class="card-body d-flex flex-column">
                         <h5 class="card-title">
                             <a href="{% url 'post_detail' slug=post.slug %}" class="stretched-link text-decoration-none text-white">
-                                {{ post.title|truncatechars:34 }}      
+                                {{ post.title|truncatechars:26 }}      
                             </a>    <!-- Truncate title to 34 characters -->
                         </h5>
                         <p class="card-text text-muted small">از {{ post.author }} در {{ post.created_at|jalali_date }}</p>

--- a/blog/templates/blog/post_list.html
+++ b/blog/templates/blog/post_list.html
@@ -31,8 +31,8 @@
                     <div class="card-body d-flex flex-column">
                         <h5 class="card-title">
                             <a href="{% url 'post_detail' slug=post.slug %}" class="stretched-link text-decoration-none text-white">
-                                {{ post.title }}
-                            </a>
+                                {{ post.title|truncatechars:34 }}      
+                            </a>    <!-- Truncate title to 34 characters -->
                         </h5>
                         <p class="card-text text-muted small">از {{ post.author }} در {{ post.created_at|jalali_date }}</p>
                         <!-- <p class="card-text mt-auto">{{ post.body|truncatewords:20|remove_empty_paragraphs|safe }}</p> -->


### PR DESCRIPTION
Fixes - #152 .

~ Implemented Django’s `truncatechars` filter to elegantly truncate overly long post titles in the list view, ensuring visual consistency without altering backend data.

To fulfill the requirement of limiting post titles to 34 characters—appending an ellipsis (...) only when the title exceeds this length—    I applied  ` post.title|truncatechars:34` here: 

https://github.com/Yadgah/Yadgah/blob/1ae5702d1ae76503ff910bf16f79e91dae6ae36a/blog/templates/blog/post_list.html#L34

Grateful thanks to @BDadmehr0 sir for the clear guidance!
I hope this enhancement contributes positively to the  repository. 