### PR TITLE
Add ls-lint configuration and pre-commit hook

### DIFF
--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -1,0 +1,37 @@
+version: 1
+
+ls:
+  .:
+    .py: snake_case
+    .yml: kebab-case
+    .yaml: kebab-case
+    .toml: snake_case
+  Yadgah:
+    .py: snake_case
+  blog:
+    .py: snake_case
+    templates:
+      .html: snake_case
+      blog:
+        .html: snake_case
+  home:
+    .py: snake_case
+    templates:
+      .html: snake_case
+      partials:
+        .html: snake_case
+      slides:
+        .html: snake_case
+  .github:
+    workflows:
+      .yml: kebab-case
+
+ignore:
+  - '.git'
+  - 'venv'
+  - 'cache'
+  - 'home/static'
+  - 'blog/static'
+  - '**/__pycache__'
+  - '**/*.pyc'
+  - 'db.sqlite3'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,13 @@ repos:
         name: djLint HTML formatter
         files: \.(html|jinja|djhtml)$
         args: [--reformat, --profile=django]
+
+  - repo: local
+    hooks:
+      - id: ls-lint
+        name: ls-lint
+        entry: npx @ls-lint/ls-lint
+        language: node
+        pass_filenames: false
+        additional_dependencies:
+          - '@ls-lint/ls-lint@2.3.1'

--- a/README.md
+++ b/README.md
@@ -89,9 +89,13 @@ Yadgah is a community-driven platform designed for sharing experiences, asking q
 
 Yadgah follows best coding practices to ensure maintainability and quality.
 
-- **Code Linting:** `flake8` for Python.
+- **Code Linting:** `flake8` for Python and `ls-lint` for filesystem naming.
 - **Pre-commit Hooks:** Automates code checks before commits.
 
+Run ls-lint manually with:
+```bash
+npx @ls-lint/ls-lint
+```
 ### GitHub Actions Workflows
 Automated workflows include:
 - **Django CI:** Ensures smooth integration.
@@ -113,3 +117,4 @@ We welcome contributions! To contribute:
 ## 🌐 Connect with Us
 
 Have questions or feedback? Reach out via [GitHub Issues](https://github.com/Yadgah/Yadgah/issues) or join our discussions.
+


### PR DESCRIPTION
Introduces .ls-lint.yml for enforcing filesystem naming conventions and updates .pre-commit-config.yaml to include an ls-lint hook. README.md is updated with instructions for using ls-lint and notes its role in code linting.

Issue #210 